### PR TITLE
feat: allow for loading WASM source inside web workers

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -248,6 +248,10 @@ function isBrowser(): boolean {
     return typeof window !== "undefined" && typeof document !== "undefined";
 }
 
+function isBrowserWorker(): boolean {
+	return typeof WorkerGlobalScope !== "undefined" && typeof self !== "undefined" && self instanceof WorkerGlobalScope;
+}
+
 async function loadWasmSource(fetchFn?: FetchLike): Promise<ArrayBuffer> {
     if (wasmSourceCache) {
         const cached = wasmSourceCache.deref();
@@ -256,7 +260,7 @@ async function loadWasmSource(fetchFn?: FetchLike): Promise<ArrayBuffer> {
 
     let moduleData: ArrayBuffer;
 
-    if (isBrowser()) {
+    if (isBrowser() || isBrowserWorker()) {
         const f = fetchFn ?? fetch;
         const response = await f(zeroperl);
         moduleData = await response.arrayBuffer();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "lib": ["DOM", "ESNext"],
+    "lib": ["DOM", "WebWorker", "ESNext"],
     "target": "ESNext",
     "module": "Preserve",
     "moduleDetection": "force",


### PR DESCRIPTION
Simply routes to the same logic as whether we are loading this from a page script.

- Detect whether we are running inside a web worker by checking whether `self` is an instance of `WorkerGlobalScope` (Solution borrowed from https://stackoverflow.com/a/18002694)
- Add WebWorker lib to tsconfig.json

Closes #5 