### PR TITLE
fix: update WASM loading logic

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -15,9 +15,6 @@ await Promise.all([
       chunk: '[name].js',
       asset: '[name].[ext]',
     },
-    loader: {
-      '.wasm': 'file',
-    },
   }),
   Bun.build({
     ...shared,

--- a/build.ts
+++ b/build.ts
@@ -15,6 +15,9 @@ await Promise.all([
       chunk: '[name].js',
       asset: '[name].[ext]',
     },
+    loader: {
+      '.wasm': 'file',
+    },
   }),
   Bun.build({
     ...shared,

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,8 +62,7 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.0.tgz",
       "integrity": "sha512-si++xzRAY9iPp60roQiFta7OFbhrgvcthrhlNAGeQptSY25uJjkfUV8OArC3KLocB8JT8ohz+qgxWCmz8RhjIg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.9.3",


### PR DESCRIPTION
This PR was vibe-coded, but it fixes an issue for me on Windows.

It seems that the path resolution on node and Windows would prepend the C:\ twice.

`C:\\C:\\Users\\{username\\Code\\the-right-tool\\node_modules\\@6over3\\zeroperl-ts\\dist\\esm\\zeroperl.wasm'` 

---

This PR makes one change:
But I'm only medium sure about it 

The change is to use the node path resolution for the wasm.
Both bun and deno support the node path resolution. So this should work.
But I have not tested it.

---

I hope this PR is correct or triggers something that fixes it.

Thanks for creating 6over3/exiftool, it was exactly what I was looking for.
I wanted the full power of exiftool and not a sloppy implementation in JS.
So thank you