### PR TITLE
fix: allows bundler to work properly for browser

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -244,10 +244,6 @@ const textEncoder = new TextEncoder();
 
 let wasmSourceCache: WeakRef<ArrayBuffer> | null = null;
 
-function isBrowser(): boolean {
-    return typeof window !== "undefined" && typeof document !== "undefined";
-}
-
 async function loadWasmSource(fetchFn?: FetchLike): Promise<ArrayBuffer> {
     if (wasmSourceCache) {
         const cached = wasmSourceCache.deref();
@@ -256,7 +252,7 @@ async function loadWasmSource(fetchFn?: FetchLike): Promise<ArrayBuffer> {
 
     let moduleData: ArrayBuffer;
 
-    if (isBrowser()) {
+    if (typeof window !== "undefined" && typeof document !== "undefined") {
         const f = fetchFn ?? fetch;
         const response = await f(zeroperl);
         moduleData = await response.arrayBuffer();


### PR DESCRIPTION
I am trying to bundle `zeroperl-ts` with webpack for browser usage.

webpack supports static replacement and static analysis for dead code elimination, and I have configured webpack to do `typeof window -> "object"` and `typeof document -> "object"`.

However, since `isBrowser` is a function that returns a boolean, even with static replacement configured, webpack can't eliminate another code branch and determined that `await import("node:fs/promises")` needs to be bundled, resulting in the following error:

```
Module build failed: UnhandledSchemeError: Reading from "node:fs/promises" is not handled by plugins (Unhandled scheme).
Webpack supports "data:" and "file:" URIs by default.
You may need an additional plugin to handle "node:" URIs.
Import trace for requested module:
```

This pull request makes a minor refactor to the environment detection logic in `index.ts`. The dedicated `isBrowser()` function was removed, and its logic was inlined directly, which allows webpack to turn the code into `if (true) { /* fetch */ } else { /* fs */ }` and eliminate the dead branch with static analysis for the browser build.